### PR TITLE
Add Promise-based REST methods as a third interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A Node.js reference implementation of the CEX.IO API. See the full docs at <https://cex.io/cex-api>
 
-* REST API
+* REST API with Callbacks or Promises
 * WebSockets API
 
 ## Installation
@@ -13,7 +13,7 @@ A Node.js reference implementation of the CEX.IO API. See the full docs at <http
 
 ## Usage
 
-### REST API
+### REST API - Callbacks
 ```
 const CEXIO = require('cexio-api-node')
 
@@ -44,6 +44,21 @@ cexAuth.account_balance(function (err, data) {
   console.log('Account balance\n', data)
 })
 ```
+
+### REST API - Promises
+```
+const CEXIO = require('cexio-api-node')
+const cexPub = new CEXIO().promiseRest
+
+cexPub.ticker('BTC/USD').then(data => {
+  console.log('Ticker\n', data)
+}).catch(err => {
+  console.error(err)
+})
+```
+
+The same pattern applies for authenticated functions.
+See Callback example for initialization.
 
 ### WebSockets API
 ```

--- a/examples/private_rest.js
+++ b/examples/private_rest.js
@@ -9,7 +9,7 @@ cexRest.account_balance(function (err, data) {
   if (err) return console.error(err)
   console.log('Account balance\n', data)
 })
-/*
+
 cexRest.open_orders('ETH/USD', function (err, data) {
   if (err) return console.error(err)
   console.log('Open orders\n', data)
@@ -79,4 +79,4 @@ cexRest.close_position('ETH/USD', 1, function (err, data) {
   if (err) return console.error(err)
   console.log('Close position\n', data)
 })
-*/
+

--- a/examples/private_rest.js
+++ b/examples/private_rest.js
@@ -9,7 +9,7 @@ cexRest.account_balance(function (err, data) {
   if (err) return console.error(err)
   console.log('Account balance\n', data)
 })
-
+/*
 cexRest.open_orders('ETH/USD', function (err, data) {
   if (err) return console.error(err)
   console.log('Open orders\n', data)
@@ -79,4 +79,4 @@ cexRest.close_position('ETH/USD', 1, function (err, data) {
   if (err) return console.error(err)
   console.log('Close position\n', data)
 })
-
+*/

--- a/examples/public_rest_promise.js
+++ b/examples/public_rest_promise.js
@@ -1,0 +1,20 @@
+// Below follows examples for use of the public REST API with Promise interfaces
+// To do authenticated requests follow the sam pattern, but provide userId, key and secret
+// in the constructor of CEXIO(). See also private_rest.js.
+
+const CEXIO = require('../index.js')
+const cex = new CEXIO()
+const cexRest = cex.promiseRest
+
+cexRest.currency_limits().then(data => {
+  console.log('Currency limits\n', data.pairs)
+}).catch(err => {
+  console.error(err)
+})
+
+cexRest.ticker('ETH/USD').then(data => {
+  console.log('ETH/USD ticker\n', data)
+}).catch(err => {
+  console.error(err)
+})
+

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const REST = require('./rest.js')
+const PROMISE_REST = require('./rest-promises.js')
 const WS = require('./ws.js')
 
 class CEXIO {
@@ -7,6 +8,7 @@ class CEXIO {
     this.apiKey = apiKey
     this.apiSecret = apiSecret
     this.rest = new REST(this.clientId, this.apiKey, this.apiSecret)
+    this.promiseRest = new PROMISE_REST(this.clientId, this.apiKey, this.apiSecret)
     this.ws = new WS(this.clientId, this.apiKey, this.apiSecret)
   }
 }

--- a/rest-promises.js
+++ b/rest-promises.js
@@ -1,0 +1,123 @@
+var _ = require('underscore')
+var restType = require('./rest')
+var rest = new restType()
+
+function promiseRest(clientId, key, secret) {
+  rest = new restType(clientId, key, secret)
+}
+
+promiseRest.prototype._promiseWrap = function(func) {
+  return new Promise((resolve, reject) => {
+    var callback = (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    }
+    var newArgs = Array.prototype.slice.call(arguments, 1);
+    newArgs.push(callback)
+    func.apply(rest, newArgs)
+  })
+}
+
+promiseRest.prototype.currency_limits = function () {
+  return this._promiseWrap(rest.currency_limits)
+}
+
+promiseRest.prototype.ticker = function (symbol) {
+  return this._promiseWrap(rest.ticker, symbol)
+}
+
+promiseRest.prototype.all_tickers = function (symbol) {
+  return this._promiseWrap(rest.all_tickers, symbol)
+}
+
+promiseRest.prototype.last_price = function (symbol) {
+  return this._promiseWrap(rest.last_price, symbol)
+}
+
+promiseRest.prototype.last_prices = function (symbol) {
+  return this._promiseWrap(rest.last_prices, symbol)
+}
+
+promiseRest.prototype.historical_1m = function (symbol, date) {
+  return this._promiseWrap(rest.historical_1m, symbol, date)
+}
+
+promiseRest.prototype.orderbook = function (symbol, limit) {
+  return this._promiseWrap(rest.orderbook, symbol, limit)
+}
+
+promiseRest.prototype.trade_history = function (symbol, tid) {
+  return this._promiseWrap(rest.trade_history, symbol, tid)
+}
+
+// Authenticated API requests
+
+promiseRest.prototype.account_balance = function () {
+  return this._promiseWrap(rest.account_balance)
+}
+
+promiseRest.prototype.open_orders = function (symbol) {
+  return this._promiseWrap(rest.open_orders, symbol)
+}
+
+promiseRest.prototype.active_orders_status = function (list) {
+  return this._promiseWrap(rest.active_orders_status, list)
+}
+
+promiseRest.prototype.archived_orders = function (symbol, limit, dateTo, dateFrom, lastTxDateTo, lastTxDateFrom, status) {
+  return this._promiseWrap(rest.archived_orders, symbol, limit, dateTo, dateFrom, lastTxDateTo, lastTxDateFrom, status)
+}
+
+promiseRest.prototype.cancel_order = function (orderId) {
+  return this._promiseWrap(rest.cancel_order, orderId)
+}
+
+promiseRest.prototype.cancel_pair_orders = function (symbol) {
+  return this._promiseWrap(rest.cancel_pair_orders, symbol)
+}
+
+promiseRest.prototype.place_order = function (symbol, type, amount, price, orderType) {
+  return this._promiseWrap(rest.place_order, symbol, type, amount, price, orderType)
+}
+
+promiseRest.prototype.get_order_details = function (orderId) {
+  return this._promiseWrap(rest.get_order_details, orderId)
+}
+
+promiseRest.prototype.get_order_transactions = function (orderId) {
+  return this._promiseWrap(rest.get_order_transactions, orderId)
+}
+
+promiseRest.prototype.get_crypto_address = function (currency) {
+  return this._promiseWrap(rest.get_crypto_address, currency)
+}
+
+promiseRest.prototype.get_my_fee = function () {
+  return this._promiseWrap(rest.get_my_fee)
+}
+
+promiseRest.prototype.replace_order = function (symbol, orderId, type, amount, price) {
+  return this._promiseWrap(rest.replace_order, symbol, orderId, type, amount, price)
+}
+
+promiseRest.prototype.open_position = function (symbol, msymbol, amount, leverage, ptype, anySlippage, eoprice, stopLossPrice) {
+  return this._promiseWrap(rest.open_position, symbol, msymbol, amount, leverage, ptype, anySlippage, eoprice, stopLossPrice)
+}
+
+promiseRest.prototype.open_positions = function (symbol) {
+  return this._promiseWrap(rest.open_positions, symbol)
+}
+
+promiseRest.prototype.close_position = function (symbol, orderId) {
+  return this._promiseWrap(rest.close_position, symbol, orderId)
+}
+
+promiseRest.prototype.archived_positions = function (symbol) {
+  return this._promiseWrap(rest.archived_positions, symbol)
+}
+
+promiseRest.prototype.get_marginal_fee = function (symbol) {
+  return this._promiseWrap(rest.get_marginal_fee, symbol)
+}
+
+module.exports = promiseRest


### PR DESCRIPTION
Should solve https://github.com/nedievas/cexio-api-node/issues/2 without breaking backwards compatibility. 

Example usage:
```
const CEXIO = require('cexio-api-node')
const cexPub = new CEXIO().promiseRest

cexPub.ticker('BTC/USD').then(data => {
  console.log('Ticker\n', data)
}).catch(err => {
  console.error(err)
})

```